### PR TITLE
Implement public_key::serialize_uncompressed calling pimpl

### DIFF
--- a/libraries/crypto/elliptic.cpp
+++ b/libraries/crypto/elliptic.cpp
@@ -181,6 +181,11 @@ compressed_public_key public_key::serialize() const
    return _my->serialize();
 }
 
+uncompressed_public_key public_key::serialize_uncompressed() const
+{
+   return _my->serialize_uncompressed();
+}
+
 public_key public_key::deserialize( const compressed_public_key& cpk )
 {
    public_key pk;


### PR DESCRIPTION
## Brief description

Fixes linking error from undefined method in pimpl pattern.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration

